### PR TITLE
Feature/cancel exercice

### DIFF
--- a/progress-tracker/API/templates/index.html
+++ b/progress-tracker/API/templates/index.html
@@ -60,6 +60,7 @@
         <button onclick="lire_recherche();">Lire</button>
         <button onclick="valider_recherche();">Valider</button>
         <button onclick="devalider_recherche();">Dévalider</button>
+        <button onclick="annuler_recherche();">Annuler démarrage et validation</button>
 
         <textarea id="commentaires_recherche" style="width:100%;height:300px;"></textarea><br />
 
@@ -104,6 +105,19 @@
             xhr.send(JSON.stringify(data));
         }
 
+        function patch_api(url, data, callback) {
+            var xhr = new XMLHttpRequest();
+            xhr.open("PATCH", url, true);
+            xhr.onreadystatechange = function () {
+                if (this.readyState == 4 && this.status == 200 && callback) {
+                    callback(JSON.parse(this.responseText));
+                }
+            };
+            xhr.setRequestHeader("Content-type", "application/json");
+            xhr.setRequestHeader("Authorization", api_token);
+            xhr.send(JSON.stringify(data));
+        }
+
         function post_api(url, data, callback) {
             var xhr = new XMLHttpRequest();
             xhr.open("POST", url, true);
@@ -132,8 +146,8 @@
             return "Première lecture il y a " + premiere_lecture + "<br/>"
                 + "Démarrage officiel il y a " + demarrage_officiel + "<br/>"
                 + "Temps passé dessus : " + delta_temps + "<br/>"
-            + (validation ? "Validation il y a " + validation + "<br/>"
-                : "");
+                + (validation ? "Validation il y a " + validation + "<br/>"
+                    : "");
         }
 
         function temps_str(temps) {
@@ -278,6 +292,12 @@
             }
         }
 
+        function annuler_recherche() {
+            // Permet aux entraîneurs de pouvoir corriger une erreur d’assignation
+            //(typiquement mauvais sujet à la mauvaise personne)
+            patch_api(cur_args[2].url, { premiere_lecture: null, demarrage_officiel: null, validation: null, faux_debut: null, debut_pause: null }, update_recherche);
+        }
+
         function valider_recherche() {
             if (cur_args.length == 2) {
                 post_api("/api/recherche/", {
@@ -317,8 +337,7 @@
                 });
             }
             else if (cur_args.length == 3) {
-                cur_args[2].commentaires = commentaires_recherche.value;
-                put_api(cur_args[2].url, cur_args[2]);
+                patch_api(cur_args[2].url, { commentaires: commentaires_recherche.value });
             }
         }
 

--- a/progress-tracker/Dockerfile
+++ b/progress-tracker/Dockerfile
@@ -1,10 +1,15 @@
 FROM python:3.7-buster
 
-#RUN apt-get update && apt-get install -y gunicorn3
-COPY . /application
-WORKDIR /application
-RUN pip install -r requirements.txt
+RUN mkdir -p /var/www && chown -R www-data:www-data /var/www
 
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+COPY . /application
+RUN chown -R www-data:www-data /application
+WORKDIR /application
+
+
+USER www-data
 EXPOSE 80:80
 
 CMD ["/bin/sh", "start.sh"]

--- a/progress-tracker/start.sh
+++ b/progress-tracker/start.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
-python3 manage.py collectstatic
+sleep 5
+python3 manage.py collectstatic --clear --noinput
+python3 manage.py migrate
 gunicorn -b 0.0.0.0:80 Progression.wsgi:application


### PR DESCRIPTION
## Ajouts

- Ajout d’un bouton dans la fenêtre _Recherche_ pour annuler un exercice donné par erreur à un candidat.

## Changements

- Utilisation de l’uitilisateur `www-data` à la place de `root` dans le conteneur Docker ;
- Utilisation de `PATCH` au lieu de `PUT` pour mettre-à-jour le commentaire sur une recherche en fermant sa fenêtre ;
- Application automatique des migrations Django lors du lancement du serveur.

Si ça vous intéresse, j’ai fait sur mon PC un `docker-compose.yml` pour lancer à la fois le serveur `progress-tracker` et une instance `mariadb`.